### PR TITLE
Respond with an ACK response to a CON block-wise request.

### DIFF
--- a/californium/src/main/java/ch/ethz/inf/vs/californium/layers/TransferLayer.java
+++ b/californium/src/main/java/ch/ethz/inf/vs/californium/layers/TransferLayer.java
@@ -464,7 +464,7 @@ public class TransferLayer extends UpperLayer {
 				if (num==0 && msg.getType()==Message.messageType.CON) {
 					block.setType(Message.messageType.CON);
 				} else {
-					block.setType(msg.isConfirmable() ? Message.messageType.ACK : Message.messageType.NON);
+					block.setType(msg.isConfirmable() || msg.isAcknowledgement() ? Message.messageType.ACK : Message.messageType.NON);
 				}
 				block.setMID(msg.getMID());
 			}


### PR DESCRIPTION
The server returns a NON response (instead of ACK) to a block-wise CON request.

To reproduce, run cf-plugtest-client against cf-plugtest-server. Test cases CB01 and CB02 fail.
The client tries to retransmit the request even after receiving the full response but the server drops it.
After DEFAULT_OVERALL_TIMEOUT the `Message.responseTimeout()` is called.

After applying this small change CB01 and CB02 test cases pass and the `Message.responseTimeout()` is not called.
