### PR TITLE
Changed to Arrays.equals when comparing tokens in PlugtestClient

### DIFF
--- a/cf-plugtest-client/src/main/java/ch/ethz/inf/vs/californium/examples/PlugtestClient.java
+++ b/cf-plugtest-client/src/main/java/ch/ethz/inf/vs/californium/examples/PlugtestClient.java
@@ -786,7 +786,7 @@ public class PlugtestClient {
                     return success;
                 }
                 
-                success &= expectedToken.equals(actualToken);
+                success &= Arrays.equals(expectedToken, actualToken);
 
                 if (!success) {
                     System.out.printf("FAIL: Expected token %s, but was %s\n", expectedToken, actualToken);


### PR DESCRIPTION
Since token is an array of bytes, Object.equals will check only the
reference, not the content.
