### PR TITLE
fix build problem using Java 7 javac

### DIFF
--- a/cf-osgi/pom.xml
+++ b/cf-osgi/pom.xml
@@ -58,6 +58,8 @@
 						</Private-Package>
 						<Import-Package>*</Import-Package>
 						<Embed-Dependency>californium;inline=true</Embed-Dependency>
+						<Embed-Dependency>element-connector;inline=true</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
 						<Bundle-SymbolicName>californium-osgi</Bundle-SymbolicName>
                     </instructions>
                 </configuration>

--- a/cf-osgi/pom.xml
+++ b/cf-osgi/pom.xml
@@ -22,17 +22,17 @@
         	<groupId>ch.ethz.inf.vs</groupId>
         	<artifactId>californium</artifactId>
         	<version>${project.version}</version>
+        	<scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>4.3.0</version>
-            <scope>provided</scope>
+            <version>4.3.1</version>
         </dependency>
         <dependency>
         	<groupId>org.osgi</groupId>
         	<artifactId>org.osgi.compendium</artifactId>
-        	<version>4.3.0</version>
+        	<version>4.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update dependency to OSGi API bundles to version 4.3.1 to avoid build problems on Java 7 javac
