### PR TITLE
Use standard JDK logging configuration

### DIFF
--- a/californium/.classpath
+++ b/californium/.classpath
@@ -6,6 +6,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/resources"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>

--- a/californium/pom.xml
+++ b/californium/pom.xml
@@ -43,5 +43,21 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <!--
+               configures the JDK Logging to use the CaliforniumFormatter
+               by means of the californium-logging.properties file
+               -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <argLine>-Djava.util.logging.config.file=${project.build.testOutputDirectory}/californium-logging.properties</argLine>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 	
 </project>

--- a/californium/src/main/java/ch/ethz/inf/vs/californium/CalifonriumLogger.java
+++ b/californium/src/main/java/ch/ethz/inf/vs/californium/CalifonriumLogger.java
@@ -1,18 +1,7 @@
 package ch.ethz.inf.vs.californium;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.text.Format;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.logging.Formatter;
-import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.LogManager;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 
 /**
  * CalifonriumLogger is a helper class for the logging in Californium.
@@ -21,250 +10,33 @@ import java.util.logging.StreamHandler;
  */
 public class CalifonriumLogger {
 	
-	/** The log policy (what to print when logging). */
-	private static LogPolicy logPolicy = new LogPolicy().dateFormat(null);
-	
-	/** A list of all loggers that have been requests over this class */
-	private static HashSet<Logger> californiumLoggers = new HashSet<Logger>();
-	
-	/** The level which each new logger will use */
-	private static Level level = null;
-	
-	private static Logger CALIFORNIUM_ROOT = Logger.getLogger("");
-	
-	static {
-		initializeLogger();
-	}
-	
 	/**
 	 * Gets the logger for the specified class. If the calling class is not the
 	 * same as the class provided, an info is printed to the logger saying, that
 	 * another class uses the logger of the specified class.
 	 * 
-	 * @param clazz the class which's logger is desired
+	 * @param clazz
+	 *            the class which's logger is desired
 	 * @return the logger
+	 * @deprecated Classes that need to log something should instead use the
+	 *             standard JDK {@link LogManager#getLogger(String)} method to
+	 *             obtain a logger. The JDK logging framework can then be
+	 *             configured to use the {@link CaliforniumFormatter} (see JDK
+	 *             JavaDocs of java.util.logging.LogManager and
+	 *             java.util.logging.Handler for details)
 	 */
 	public static Logger getLogger(Class<?> clazz) {
 		if (clazz == null) throw new NullPointerException();
 		StackTraceElement[] trace = Thread.currentThread().getStackTrace();
 		Logger logger = Logger.getLogger(clazz.getName());
-		logger.setParent(CALIFORNIUM_ROOT);
-		if (level != null) logger.setLevel(level);
 		String caller = trace[2].getClassName();
-		if (!caller.equals(clazz.getName()))
-			logger.info("Note that class "+caller+" uses the logger of class "+clazz.getName());
-		californiumLoggers.add(logger);
+		if (!caller.equals(clazz.getName())) {
+			logger.info(String.format("Note that class [%s] uses the logger of class [%s]", caller, clazz.getName()));
+		}
 		return logger;
 	}
 	
 	public static void printLoggerFormat() {
-		CALIFORNIUM_ROOT.info("Logging format: Thread-ID | Level | Message - Class | Line No. | Method name | Thread name");
-	}
-	
-	/**
-	 * Initializes the logger. The resulting format of logged messages is
-	 * 
-	 * <pre>
-	 * {@code
-	 * | Thread ID | Level | Message | Class | Line No | Method | Thread name |
-	 * }
-	 * </pre>
-	 * 
-	 * where Level is the {@link Level} of the message, the <code>Class</code>
-	 * is the class in which the log statement is located, the
-	 * <code>Line No</code> is the line number of the logging statement, the
-	 * <code>Method</code> is the method name in which the statement is located
-	 * and the <code>Thread name</code> is the name of the thread that executed
-	 * the logging statement.
-	 */
-	private static void initializeLogger() {
-		try {
-			LogManager.getLogManager().reset();
-			
-			Handler handler = new StreamHandler(System.out, new Formatter() {
-			    @Override
-			    public synchronized String format(LogRecord record) {
-			    	String stackTrace = "";
-			    	Throwable throwable = record.getThrown();
-			    	if (throwable != null) {
-			    		StringWriter sw = new StringWriter();
-			    		throwable.printStackTrace(new PrintWriter(sw));
-			    		stackTrace = sw.toString();
-			    	}
-			    	
-			    	int lineNo;
-			    	StackTraceElement[] stack = Thread.currentThread().getStackTrace();
-			    	if (throwable != null && stack.length > 7)
-			    		lineNo = stack[7].getLineNumber();
-			    	else if (stack.length > 8)
-			    		lineNo = stack[8].getLineNumber();
-			    	else lineNo = -1;
-			    	
-			    	LogPolicy p = logPolicy;
-			        return iftrue(p.showTheadID, String.format("%2d", record.getThreadID()) + " ")
-			        		+ iftrue(p.showLevel, record.getLevel()+" ")
-			        		+ iftrue(p.showClass, "[" + getSimpleClassName(record.getSourceClassName()) + "]: ")
-			        		+ iftrue(p.showMessage, record.getMessage())
-			        		+ iftrue(p.showSource, " - ("+record.getSourceClassName()+".java:"+lineNo+") ")
-			        		+ iftrue(p.showMethod, record.getSourceMethodName()+"()")
-			                + iftrue(p.showThread, " in thread " + Thread.currentThread().getName())
-			                + (p.dateFormat != null
-			                	? " at (" + p.dateFormat.format( new Date(record.getMillis()) ) +")"
-			                	: "")
-			                +"\n" + stackTrace;
-			    }
-			}) {
-				@Override
-				public synchronized void publish(LogRecord record) {
-					super.publish(record);
-					super.flush();
-				}
-			};
-			handler.setLevel(Level.ALL);
-			CALIFORNIUM_ROOT.addHandler(handler);
-		} catch (Throwable t) {
-			t.printStackTrace();
-		}
-	}
-	
-	/**
-	 * Returns the specified string if the specified boolean is true and returns
-	 * the empty string otherwise.
-	 * 
-	 * @param b the boolean
-	 * @param s the string
-	 * @return the string if the boolean is true
-	 */
-	private static String iftrue(boolean b, String s) {
-		return b ? s : "";
-	}
-	
-	/**
-	 * Gets the simple class name.
-	 *
-	 * @param absolute the absolute class name
-	 * @return the simple class name
-	 */
-	private static String getSimpleClassName(String absolute) {
-		String[] parts = absolute.split("\\.");
-		return parts[parts.length -1];
-	}
-	
-	/**
-	 * Disables logging by setting the level of all loggers that have been
-	 * requested over this class to OFF.
-	 */
-	public static void disableLogging() {
-		setLoggerLevel(Level.OFF);
-	}
-	
-	/**
-	 * Sets the logger level of all loggers that have been requests over this
-	 * class to the specified level and sets this level for all loggers that are
-	 * going to be requested over this class in the future.
-	 * 
-	 * @param level the new logger level
-	 */
-	public static void setLoggerLevel(Level level) {
-		CalifonriumLogger.level = level;
-		for (Logger logger:californiumLoggers)
-			logger.setLevel(level);
-	}
-
-	/**
-	 * Gets the current logging policy.
-	 *
-	 * @return the log policy
-	 */
-	public static LogPolicy getLogPolicy() {
-		return logPolicy;
-	}
-
-	/**
-	 * Sets the logging policy.
-	 *
-	 * @param logPolicy the new log policy
-	 */
-	public static void setLogPolicy(LogPolicy logPolicy) {
-		CalifonriumLogger.logPolicy = logPolicy;
-	}
-	
-	/**
-	 * This class represents the properties how logging records are represented. 
-	 */
-	// Defining logging properties in the NetworkConfig leads to a bootstrap
-	// problem: The NetworkConfig wants to write a log when loading the
-	// properties and the log wants to know the logging properties when writing
-	// that log.
-	public static class LogPolicy {
-		
-		public boolean showTheadID = true;
-		public boolean showLevel = true;
-		public boolean showClass = true;
-		public boolean showMessage = true;
-		public boolean showSource = true;
-		public boolean showMethod = true;
-		public boolean showThread = true;
-		public Format dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		
-		/**
-		 * Instantiates a new log policy.
-		 */
-		public LogPolicy() { }
-		
-		/**
-		 * Instantiates a new log policy.
-		 *
-		 * @param showTheadID the show thread id
-		 * @param showLevel the show level
-		 * @param showClass the show class
-		 * @param showMessage the show message
-		 * @param showSource the show source
-		 * @param showMethod the show method
-		 * @param showThread the show thread
-		 * @param dateFormat the date format
-		 */
-		public LogPolicy(
-				boolean showTheadID, 
-				boolean showLevel,
-				boolean showClass, 
-				boolean showMessage, 
-				boolean showSource,
-				boolean showMethod,
-				boolean showThread, 
-				Format dateFormat) {
-			this.showTheadID = showTheadID;
-			this.showLevel = showLevel;
-			this.showClass = showClass;
-			this.showMessage = showMessage;
-			this.showSource = showSource;
-			this.showMethod = showMethod;
-			this.showThread = showThread;
-			this.dateFormat = dateFormat;
-		}
-
-		public LogPolicy showThreadID() { showTheadID = true; return this; }
-		public LogPolicy showLevel() { showLevel = true; return this; }
-		public LogPolicy showClass() { showClass = true; return this; }
-		public LogPolicy showMessage() { showMessage = true; return this; }
-		public LogPolicy showSource() { showSource = true; return this; }
-		public LogPolicy showMethod() { showMethod = true; return this; }
-		public LogPolicy showThread() { showThread = true; return this; }
-		public LogPolicy hideThreadID() { showTheadID = false; return this; }
-		public LogPolicy hideLevel() { showLevel = false; return this; }
-		public LogPolicy hideClass() { showClass = false; return this; }
-		public LogPolicy hideMessage() { showMessage = false; return this; }
-		public LogPolicy hideSource() { showSource = false; return this; }
-		public LogPolicy hideMethod() { showMethod = false; return this; }
-		public LogPolicy hideThread() { showThread = false; return this; }
-
-		/**
-		 * Sets the specified format
-		 * @param format
-		 * @return this
-		 */
-		public LogPolicy dateFormat(Format format) {
-			this.dateFormat = format; return this;
-		}
+		CalifonriumLogger.getLogger(CalifonriumLogger.class).info("Logging format: Thread-ID | Level | Message - Class | Line No. | Method name | Thread name");
 	}
 }

--- a/californium/src/main/java/ch/ethz/inf/vs/californium/CaliforniumFormatter.java
+++ b/californium/src/main/java/ch/ethz/inf/vs/californium/CaliforniumFormatter.java
@@ -1,0 +1,163 @@
+package ch.ethz.inf.vs.californium;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Formatter;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+/**
+ * A JDK Logging Formatter that produces Californium specific log statements.
+ * 
+ * This formatter can be configured by means of a standard JDK logging
+ * configuration file (see <a href=
+ * "http://docs.oracle.com/javase/6/docs/api/java/util/logging/package-summary.html"
+ * >java.util.logging</a> JavaDocs and in particular the LogManager and Handler
+ * class documentation for details on how to do this).
+ * 
+ * @author Kai Hudalla
+ * @since 0.18.1
+ */
+public class CaliforniumFormatter extends Formatter {
+
+	private LogPolicy logPolicy;
+	
+	/**
+	 * Initializes the log policy with default values.
+	 */
+	public CaliforniumFormatter() {
+		logPolicy = new LogPolicy();
+	}
+	
+	@Override
+	public String format(LogRecord record) {
+
+		String stackTrace = "";
+    	Throwable throwable = record.getThrown();
+    	if (throwable != null) {
+    		StringWriter sw = new StringWriter();
+    		throwable.printStackTrace(new PrintWriter(sw));
+    		stackTrace = sw.toString();
+    	}
+    	
+    	int lineNo;
+    	StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+    	if (throwable != null && stack.length > 7)
+    		lineNo = stack[7].getLineNumber();
+    	else if (stack.length > 8)
+    		lineNo = stack[8].getLineNumber();
+    	else lineNo = -1;
+    	
+    	StringBuffer b = new StringBuffer();
+    	if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_THREAD_ID)) {
+			b.append(String.format("%2d", record.getThreadID())).append(" ");
+		}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_LEVEL)) {
+			b.append(record.getLevel().toString()).append(" ");
+		}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_CLASS)) {
+			b.append("[").append(getSimpleClassName(record.getSourceClassName())).append("]: ");
+		}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_MESSAGE)) {
+			b.append(record.getMessage());
+		}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_SOURCE)) {
+			b.append(" - (").append(record.getSourceClassName()).append(".java:").append(lineNo).append(") ");
+    	}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_METHOD)) {
+			b.append(record.getSourceMethodName()).append("()");
+		}
+		if (logPolicy.isEnabled(LogPolicy.LOG_POLICY_SHOW_THREAD)) {
+			b.append(" in thread ").append(Thread.currentThread().getName());
+		}
+		if (logPolicy.dateFormat != null) {
+			b.append(" at (").append(logPolicy.dateFormat.format(new Date(record.getMillis()))).append(")");
+        }
+		b.append("\n").append(stackTrace);
+        return b.toString();
+	}
+
+	/**
+	 * Gets the simple class name.
+	 *
+	 * @param absolute the absolute class name
+	 * @return the simple class name
+	 */
+	private static String getSimpleClassName(String absolute) {
+		String[] parts = absolute.split("\\.");
+		return parts[parts.length -1];
+	}
+	
+	/**
+	 * A set of boolean properties controlling the content of the log statement
+	 * returned by {@link CaliforniumFormatter#format(LogRecord)}.
+	 */
+	private static class LogPolicy {
+		
+		private static final String LOG_POLICY_SHOW_CLASS = "californium.LogPolicy.showClass";
+		private static final String LOG_POLICY_SHOW_LEVEL = "californium.LogPolicy.showLevel";
+		private static final String LOG_POLICY_SHOW_METHOD = "californium.LogPolicy.showMethod";
+		private static final String LOG_POLICY_SHOW_MESSAGE = "californium.LogPolicy.showMessage";
+		private static final String LOG_POLICY_SHOW_SOURCE = "californium.LogPolicy.showSource";
+		private static final String LOG_POLICY_SHOW_THREAD = "californium.LogPolicy.showThread";
+		private static final String LOG_POLICY_SHOW_THREAD_ID = "californium.LogPolicy.showThreadID";
+		private static final String LOG_POLICY_DATE_FORMAT = "californium.LogPolicy.dateFormat";
+
+		private Map<String, Boolean> policy = new HashMap<String, Boolean>();		
+		private Format dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		
+		/**
+		 * Instantiates a new log policy.
+		 */
+		private LogPolicy() {
+			
+			addPolicy(LOG_POLICY_SHOW_CLASS, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_LEVEL, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_CLASS, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_MESSAGE, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_METHOD, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_SOURCE, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_THREAD, Boolean.TRUE);
+			addPolicy(LOG_POLICY_SHOW_THREAD_ID, Boolean.TRUE);
+
+			// initialize date format from property specified in JDK logging
+			// configuration
+			String df = LogManager.getLogManager().getProperty(LOG_POLICY_DATE_FORMAT);
+			if ( df != null) {
+				dateFormat = new SimpleDateFormat(df);
+			}
+		}
+		
+		/**
+		 * Adds a particular configuration property for controlling content to
+		 * be included in the formatter's output.
+		 * 
+		 * @param propertyName
+		 *            the name of the property to add to the policy
+		 * @param defaultValue
+		 *            the value to fall back to if the {@link LogManager} does
+		 *            not contain a value for the configuration property
+		 * @return the updated policy
+		 */
+		private LogPolicy addPolicy(String propertyName, boolean defaultValue) {
+			String flag = LogManager.getLogManager().getProperty(propertyName);
+			if (flag != null) {
+				policy.put(propertyName, Boolean.parseBoolean(flag));
+			} else {
+				policy.put(propertyName, defaultValue);
+			}
+			return this;
+		}
+		
+		private boolean isEnabled(String propertyName) {
+			Boolean result = policy.get(propertyName);
+			return result != null ? result : false;
+		}
+	}
+	
+}

--- a/californium/src/test/resources/californium-logging.properties
+++ b/californium/src/test/resources/californium-logging.properties
@@ -1,0 +1,64 @@
+############################################################
+#  	Californium Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= WARN
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = ch.ethz.inf.vs.californium.CaliforniumFormatter
+
+# Limit the message that are printed on the console to FINE and above.
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = ch.ethz.inf.vs.californium.CaliforniumFormatter
+
+# Properties for configuring the content included by the CaliforniumFormatter when producing
+# log statements (see ch.ethz.inf.vs.californium.CaliforniumFormatter.java)
+californium.LogPolicy.showClass=true
+californium.LogPolicy.showLevel=true
+californium.LogPolicy.showMethod=true
+californium.LogPolicy.showMessage=true
+californium.LogPolicy.showSource=true
+californium.LogPolicy.showThread=true
+californium.LogPolicy.showThreadID=true
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# Write messages logged by Californium class to the console
+ch.ethz.inf.vs.californium.handlers = java.util.logging.ConsoleHandler
+ch.ethz.inf.vs.californium.useParentHandlers = false
+ch.ethz.inf.vs.californium.level = INFO


### PR DESCRIPTION
Hi Matthias,

I have refactored the LogPolicy into a JDK logging Formatter class which can be configured in a logging configuration file. I have included an example file (under src/test/resources) which is already used for running the unit tests (see pom.xml). When using this approach for a standalone server, the VM parameter for configuring the logging configuration file needs to be provided on the command line. Using this approach it also doesn't make much sense for all the other classes to refer to CaliforniumLogger in order to get a logger. Instead, they should simply use the standard JDK LogManager.getLogger() method ... all configuration can be done using the properties file ...
