### PR TITLE
Renamed ResourceBase.respond to checkObserveAndRespond

### DIFF
--- a/californium/src/main/java/ch/ethz/inf/vs/californium/server/resources/CoapExchange.java
+++ b/californium/src/main/java/ch/ethz/inf/vs/californium/server/resources/CoapExchange.java
@@ -205,6 +205,6 @@ public class CoapExchange {
 		if (response == null) throw new NullPointerException();
 		if (locationPath != null)
 			response.getOptions().setLocationPath(locationPath);
-		resource.respond(exchange, response);
+		resource.checkObserveAndRespond(exchange, response);
 	}
 }

--- a/californium/src/main/java/ch/ethz/inf/vs/californium/server/resources/ResourceBase.java
+++ b/californium/src/main/java/ch/ethz/inf/vs/californium/server/resources/ResourceBase.java
@@ -279,7 +279,7 @@ public  class ResourceBase implements Resource {
 	 * @param exchange the exchange
 	 * @param response the response
 	 */
-	protected void respond(Exchange exchange, Response response) {
+	protected void checkObserveAndRespond(Exchange exchange, Response response) {
 		if (exchange == null) throw new NullPointerException();
 		if (response == null) throw new NullPointerException();
 		checkObserveRelation(exchange, response);

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/ClientAsynchronousTest.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/ClientAsynchronousTest.java
@@ -205,7 +205,7 @@ public class ClientAsynchronousTest {
 			
 			Response response = new Response(ResponseCode.CONTENT);
 			response.setPayload(c);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 		
 		@Override
@@ -214,7 +214,7 @@ public class ClientAsynchronousTest {
 			this.content = exchange.getRequest().getPayloadString();
 			Response response = new Response(ResponseCode.CHANGED);
 			response.setPayload(old);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 			changed();
 		}
 	}

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/ClientSynchronousTest.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/ClientSynchronousTest.java
@@ -163,7 +163,7 @@ public class ClientSynchronousTest {
 			
 			Response response = new Response(ResponseCode.CONTENT);
 			response.setPayload(c);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 		
 		@Override
@@ -172,7 +172,7 @@ public class ClientSynchronousTest {
 			this.content = exchange.getRequest().getPayloadString();
 			Response response = new Response(ResponseCode.CHANGED);
 			response.setPayload(old);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 			changed();
 		}
 	}

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/ObserveDraft08Test.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/ObserveDraft08Test.java
@@ -191,7 +191,7 @@ public class ObserveDraft08Test {
 			Response response = new Response(ResponseCode.CONTENT);
 			response.setPayload(currentResponse);
 			response.setType(type);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 		
 		private void setNotificationType(Type type) {

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/ObserveTest2.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/ObserveTest2.java
@@ -236,7 +236,7 @@ public class ObserveTest2 {
 			Response response = new Response(ResponseCode.CONTENT);
 			response.setPayload(currentResponse);
 			response.setType(type);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 		
 		@Override

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/ResourceTreeTest.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/ResourceTreeTest.java
@@ -108,7 +108,7 @@ public class ResourceTreeTest {
 		public void handleGET(Exchange exchange) {
 			Response response = new Response(ResponseCode.CONTENT);
 			response.setPayload(payload);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 	}
 }

--- a/californium/src/test/java/ch/ethz/inf/vs/californium/test/lockstep/ObserveServerSide.java
+++ b/californium/src/test/java/ch/ethz/inf/vs/californium/test/lockstep/ObserveServerSide.java
@@ -312,7 +312,7 @@ private static boolean RANDOM_PAYLOAD_GENERATION = true;
 			Response response = new Response(CONTENT);
 			response.setType(respType);
 			response.setPayload(respPayload);
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 		
 		public void change(String newPayload) {

--- a/cf-benchmark/src/main/java/ch/ethz/inf/vs/californium/benchmark/BenchmarkResource.java
+++ b/cf-benchmark/src/main/java/ch/ethz/inf/vs/californium/benchmark/BenchmarkResource.java
@@ -20,7 +20,7 @@ public class BenchmarkResource extends ResourceBase {
 	public void handleGET(Exchange exchange) {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setPayload("hello world");
-		respond(exchange, response);
+		checkObserveAndRespond(exchange, response);
 	}
 
 }

--- a/cf-plugtest-server/src/main/java/ch/ethz/inf/vs/californium/examples/plugtest/Observe.java
+++ b/cf-plugtest-server/src/main/java/ch/ethz/inf/vs/californium/examples/plugtest/Observe.java
@@ -127,7 +127,7 @@ public class Observe extends ResourceBase {
 			response.setType(Type.CON);
 
 			// complete the request
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 
 	}

--- a/cf-plugtest-server/src/main/java/ch/ethz/inf/vs/californium/examples/plugtest/ObserveNon.java
+++ b/cf-plugtest-server/src/main/java/ch/ethz/inf/vs/californium/examples/plugtest/ObserveNon.java
@@ -127,7 +127,7 @@ public class ObserveNon extends ResourceBase {
 			response.setType(Type.NON);
 
 			// complete the request
-			respond(exchange, response);
+			checkObserveAndRespond(exchange, response);
 		}
 
 	}

--- a/cf-server/src/main/java/ch/ethz/inf/vs/californium/examples/resources/HelloWorldResource.java
+++ b/cf-server/src/main/java/ch/ethz/inf/vs/californium/examples/resources/HelloWorldResource.java
@@ -20,7 +20,7 @@ public class HelloWorldResource extends ResourceBase {
 	public void handleGET(Exchange exchange) {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setPayload("hello world");
-		respond(exchange, response);
+		checkObserveAndRespond(exchange, response);
 	}
 
 }


### PR DESCRIPTION
This should make it a little clearer how to observe a resource. Optimal would be to make `Exchange.respond` do this.

This addresses my main concern in #57, but we could still use more documentation.
